### PR TITLE
bug fix sample_marginal

### DIFF
--- a/R/03-summary-statistics.R
+++ b/R/03-summary-statistics.R
@@ -649,7 +649,8 @@ sample_marginal.marginallaplace <- function(quad,M,transformation = quad$transfo
     # function(.x,.y) as.numeric(solve(simlist$L[[as.numeric(.y)]],.x)) + do.call(cbind,rep(list(simlist$mode[[as.numeric(.y)]]),ncol(.x))),
     function(.x,.y) as.numeric(Matrix::solve(simlist$L[[as.numeric(.y)]],Matrix::solve(simlist$L[[as.numeric(.y)]],.x,system="Lt"),system='Pt')) + do.call(cbind,rep(list(simlist$mode[[as.numeric(.y)]]),ncol(.x))),
     Z,
-    names(Z)
+    names(Z),
+    SIMPLIFY = F
   )
 
   # Order them properly


### PR DESCRIPTION
Added SIMPLIFY = F in the mapply call creating samps to insure that it stays a list even when Z has length one (which should raise a red flag in the first place). This happens for example when quad$normalized_posterior$nodesandweights$logpost_normalized is very close to c(0,1,0), which is not a good thing...