### PR TITLE
Issue 6 fix

### DIFF
--- a/R/02-normalization.R
+++ b/R/02-normalization.R
@@ -34,10 +34,6 @@
 #' \item{\code{lognormconst}: }{the actual result of the quadrature: the log of the normalizing constant of the posterior.}
 #' }
 #'
-#' If k = 1, then the method returns
-#' a numeric value representing the log of the normalizing constant computed using
-#' a Laplace approximation.
-#'
 #' @family quadrature
 #'
 #' @examples
@@ -80,10 +76,6 @@
 #'
 normalize_logpost <- function(optresults,k,whichfirst = 1,basegrid = NULL,ndConstruction = "product",...) {
   if (as.integer(k) != k) stop(paste0("Please provide an integer k, the number of quadrature points. You provided ",k,"which does not satisfy as.integer(k) == k"))
-  if (k == 1) {
-    # Laplace approx: just return the normalizing constant
-    return(optresults$ff$fn(optresults$mode,...) - as.numeric(.5 * determinant(optresults$hessian,logarithm = TRUE)$modulus) + .5*dim(optresults$hessian)[1]*log(2*pi))
-  }
   # Create the grid
   S <- length(optresults$mode) # Dimension
   if (!is.null(basegrid)) {

--- a/tests/testthat/setup-01-optimization.R
+++ b/tests/testthat/setup-01-optimization.R
@@ -21,24 +21,25 @@ opt_sr1 <- optimize_theta(funlist,1.5,control = default_control(method = "SR1"))
 opt_trust <- optimize_theta(funlist,1.5,control = default_control(method = "trust"))
 opt_bfgs <- optimize_theta(funlist,1.5,control = default_control(method = "BFGS"))
 
+norm_sparse_1 <- normalize_logpost(opt_sparsetrust,1,1)
 norm_sparse_3 <- normalize_logpost(opt_sparsetrust,3,1)
 norm_sparse_5 <- normalize_logpost(opt_sparsetrust,5,1)
 norm_sparse_7 <- normalize_logpost(opt_sparsetrust,7,1)
 
+norm_trust_1 <- normalize_logpost(opt_trust,3,1)
 norm_trust_3 <- normalize_logpost(opt_trust,3,1)
 norm_trust_5 <- normalize_logpost(opt_trust,5,1)
 norm_trust_7 <- normalize_logpost(opt_trust,7,1)
 
+norm_bfgs_1 <- normalize_logpost(opt_bfgs,3,1)
 norm_bfgs_3 <- normalize_logpost(opt_bfgs,3,1)
 norm_bfgs_5 <- normalize_logpost(opt_bfgs,5,1)
 norm_bfgs_7 <- normalize_logpost(opt_bfgs,7,1)
 
+norm_sr1_1 <- normalize_logpost(opt_sr1,3,1)
 norm_sr1_3 <- normalize_logpost(opt_sr1,3,1)
 norm_sr1_5 <- normalize_logpost(opt_sr1,5,1)
 norm_sr1_7 <- normalize_logpost(opt_sr1,7,1)
-
-
-
 
 margpost_3 <- marginal_posterior(opt_sparsetrust,3,1)
 pdfwithtrans <- compute_pdf_and_cdf(
@@ -88,18 +89,22 @@ opt_trust_2d <- optimize_theta(funlist2d,c(1.5,1.5),control = default_control(me
 opt_sr1_2d <- optimize_theta(funlist2d,c(1.5,1.5),control = default_control(method = "SR1"))
 opt_bfgs_2d <- optimize_theta(funlist2d,c(1.5,1.5),control = default_control(method = "BFGS"))
 
+norm_sparse_2d_1 <- normalize_logpost(opt_sparsetrust_2d,1,1)
 norm_sparse_2d_3 <- normalize_logpost(opt_sparsetrust_2d,3,1)
 norm_sparse_2d_5 <- normalize_logpost(opt_sparsetrust_2d,5,1)
 norm_sparse_2d_7 <- normalize_logpost(opt_sparsetrust_2d,7,1)
 
+norm_trust_2d_1 <- normalize_logpost(opt_trust_2d,1,1)
 norm_trust_2d_3 <- normalize_logpost(opt_trust_2d,3,1)
 norm_trust_2d_5 <- normalize_logpost(opt_trust_2d,5,1)
 norm_trust_2d_7 <- normalize_logpost(opt_trust_2d,7,1)
 
+norm_bfgs_2d_1 <- normalize_logpost(opt_bfgs_2d,1,1)
 norm_bfgs_2d_3 <- normalize_logpost(opt_bfgs_2d,3,1)
 norm_bfgs_2d_5 <- normalize_logpost(opt_bfgs_2d,5,1)
 norm_bfgs_2d_7 <- normalize_logpost(opt_bfgs_2d,7,1)
 
+norm_sr1_2d_1 <- normalize_logpost(opt_sr1_2d,1,1)
 norm_sr1_2d_3 <- normalize_logpost(opt_sr1_2d,3,1)
 norm_sr1_2d_5 <- normalize_logpost(opt_sr1_2d,5,1)
 norm_sr1_2d_7 <- normalize_logpost(opt_sr1_2d,7,1)
@@ -253,18 +258,22 @@ opt_trust_3d <- optimize_theta(funlist3d,c(1.5,1.5,1.5),control = default_contro
 opt_sr1_3d <- optimize_theta(funlist3d,c(1.5,1.5,1.5),control = default_control(method = "SR1"))
 opt_bfgs_3d <- optimize_theta(funlist3d,c(1.5,1.5,1.5),control = default_control(method = "BFGS"))
 
+norm_sparse_3d_1 <- normalize_logpost(opt_sparsetrust_3d,1,1)
 norm_sparse_3d_3 <- normalize_logpost(opt_sparsetrust_3d,3,1)
 norm_sparse_3d_5 <- normalize_logpost(opt_sparsetrust_3d,5,1)
 norm_sparse_3d_7 <- normalize_logpost(opt_sparsetrust_3d,7,1)
 
+norm_trust_3d_1 <- normalize_logpost(opt_trust_3d,1,1)
 norm_trust_3d_3 <- normalize_logpost(opt_trust_3d,3,1)
 norm_trust_3d_5 <- normalize_logpost(opt_trust_3d,5,1)
 norm_trust_3d_7 <- normalize_logpost(opt_trust_3d,7,1)
 
+norm_bfgs_3d_1 <- normalize_logpost(opt_bfgs_3d,1,1)
 norm_bfgs_3d_3 <- normalize_logpost(opt_bfgs_3d,3,1)
 norm_bfgs_3d_5 <- normalize_logpost(opt_bfgs_3d,5,1)
 norm_bfgs_3d_7 <- normalize_logpost(opt_bfgs_3d,7,1)
 
+norm_sr1_3d_1 <- normalize_logpost(opt_sr1_3d,1,1)
 norm_sr1_3d_3 <- normalize_logpost(opt_sr1_3d,3,1)
 norm_sr1_3d_5 <- normalize_logpost(opt_sr1_3d,5,1)
 norm_sr1_3d_7 <- normalize_logpost(opt_sr1_3d,7,1)

--- a/tests/testthat/test-02-normalization.R
+++ b/tests/testthat/test-02-normalization.R
@@ -2,148 +2,184 @@ context("Normalization")
 
 test_that("Normalization works",{
     # Return correct object
+    expect_length(norm_sparse_1,3)
     expect_length(norm_sparse_3,3)
     expect_length(norm_sparse_5,3)
     expect_length(norm_sparse_7,3)
 
+    expect_length(norm_trust_1,3)
     expect_length(norm_trust_3,3)
     expect_length(norm_trust_5,3)
     expect_length(norm_trust_7,3)
 
+    expect_length(norm_bfgs_1,3)
     expect_length(norm_bfgs_3,3)
     expect_length(norm_bfgs_5,3)
     expect_length(norm_bfgs_7,3)
 
+    expect_length(norm_sr1_1,3)
     expect_length(norm_sr1_3,3)
     expect_length(norm_sr1_5,3)
     expect_length(norm_sr1_7,3)
 
+    expect_length(norm_sparse_2d_1,3)
     expect_length(norm_sparse_2d_3,3)
     expect_length(norm_sparse_2d_5,3)
     expect_length(norm_sparse_2d_7,3)
 
+    expect_length(norm_trust_2d_1,3)
     expect_length(norm_trust_2d_3,3)
     expect_length(norm_trust_2d_5,3)
     expect_length(norm_trust_2d_7,3)
 
+    expect_length(norm_bfgs_2d_1,3)
     expect_length(norm_bfgs_2d_3,3)
     expect_length(norm_bfgs_2d_5,3)
     expect_length(norm_bfgs_2d_7,3)
 
+    expect_length(norm_sr1_2d_1,3)
     expect_length(norm_sr1_2d_3,3)
     expect_length(norm_sr1_2d_5,3)
     expect_length(norm_sr1_2d_7,3)
 
+    expect_length(norm_sparse_3d_1,3)
     expect_length(norm_sparse_3d_3,3)
     expect_length(norm_sparse_3d_5,3)
     expect_length(norm_sparse_3d_7,3)
 
+    expect_length(norm_trust_3d_1,3)
     expect_length(norm_trust_3d_3,3)
     expect_length(norm_trust_3d_5,3)
     expect_length(norm_trust_3d_7,3)
 
+    expect_length(norm_bfgs_3d_1,3)
     expect_length(norm_bfgs_3d_3,3)
     expect_length(norm_bfgs_3d_5,3)
     expect_length(norm_bfgs_3d_7,3)
 
+    expect_length(norm_sr1_3d_1,3)
     expect_length(norm_sr1_3d_3,3)
     expect_length(norm_sr1_3d_5,3)
     expect_length(norm_sr1_3d_7,3)
 
     # Correct number of nodes
+    expect_equal(nrow(norm_sparse_1$nodesandweights),1)
     expect_equal(nrow(norm_sparse_3$nodesandweights),3)
     expect_equal(nrow(norm_sparse_5$nodesandweights),5)
     expect_equal(nrow(norm_sparse_7$nodesandweights),7)
 
+    expect_equal(nrow(norm_sr1_1$nodesandweights),1)
     expect_equal(nrow(norm_sr1_3$nodesandweights),3)
     expect_equal(nrow(norm_sr1_5$nodesandweights),5)
     expect_equal(nrow(norm_sr1_7$nodesandweights),7)
 
+    expect_equal(nrow(norm_trust_1$nodesandweights),1)
     expect_equal(nrow(norm_trust_3$nodesandweights),3)
     expect_equal(nrow(norm_trust_5$nodesandweights),5)
     expect_equal(nrow(norm_trust_7$nodesandweights),7)
 
+    expect_equal(nrow(norm_bfgs_1$nodesandweights),1)
     expect_equal(nrow(norm_bfgs_3$nodesandweights),3)
     expect_equal(nrow(norm_bfgs_5$nodesandweights),5)
     expect_equal(nrow(norm_bfgs_7$nodesandweights),7)
 
+    expect_equal(nrow(norm_sparse_2d_1$nodesandweights),1^2)
     expect_equal(nrow(norm_sparse_2d_3$nodesandweights),3^2)
     expect_equal(nrow(norm_sparse_2d_5$nodesandweights),5^2)
     expect_equal(nrow(norm_sparse_2d_7$nodesandweights),7^2)
 
+    expect_equal(nrow(norm_trust_2d_1$nodesandweights),1^2)
     expect_equal(nrow(norm_trust_2d_3$nodesandweights),3^2)
     expect_equal(nrow(norm_trust_2d_5$nodesandweights),5^2)
     expect_equal(nrow(norm_trust_2d_7$nodesandweights),7^2)
 
+    expect_equal(nrow(norm_bfgs_2d_1$nodesandweights),1^2)
     expect_equal(nrow(norm_bfgs_2d_3$nodesandweights),3^2)
     expect_equal(nrow(norm_bfgs_2d_5$nodesandweights),5^2)
     expect_equal(nrow(norm_bfgs_2d_7$nodesandweights),7^2)
 
+    expect_equal(nrow(norm_sr1_2d_1$nodesandweights),1^2)
     expect_equal(nrow(norm_sr1_2d_3$nodesandweights),3^2)
     expect_equal(nrow(norm_sr1_2d_5$nodesandweights),5^2)
     expect_equal(nrow(norm_sr1_2d_7$nodesandweights),7^2)
 
+    expect_equal(nrow(norm_sparse_3d_1$nodesandweights),1^3)
     expect_equal(nrow(norm_sparse_3d_3$nodesandweights),3^3)
     expect_equal(nrow(norm_sparse_3d_5$nodesandweights),5^3)
     expect_equal(nrow(norm_sparse_3d_7$nodesandweights),7^3)
 
+    expect_equal(nrow(norm_trust_3d_1$nodesandweights),1^3)
     expect_equal(nrow(norm_trust_3d_3$nodesandweights),3^3)
     expect_equal(nrow(norm_trust_3d_5$nodesandweights),5^3)
     expect_equal(nrow(norm_trust_3d_7$nodesandweights),7^3)
 
+    expect_equal(nrow(norm_bfgs_3d_1$nodesandweights),1^3)
     expect_equal(nrow(norm_bfgs_3d_3$nodesandweights),3^3)
     expect_equal(nrow(norm_bfgs_3d_5$nodesandweights),5^3)
     expect_equal(nrow(norm_bfgs_3d_7$nodesandweights),7^3)
 
+    expect_equal(nrow(norm_sr1_3d_1$nodesandweights),1^3)
     expect_equal(nrow(norm_sr1_3d_3$nodesandweights),3^3)
     expect_equal(nrow(norm_sr1_3d_5$nodesandweights),5^3)
     expect_equal(nrow(norm_sr1_3d_7$nodesandweights),7^3)
 
     # Normconst is not infinite
+    expect_false(is.infinite(norm_sparse_1$lognormconst))
     expect_false(is.infinite(norm_sparse_3$lognormconst))
     expect_false(is.infinite(norm_sparse_5$lognormconst))
     expect_false(is.infinite(norm_sparse_7$lognormconst))
 
+    expect_false(is.infinite(norm_sr1_1$lognormconst))
     expect_false(is.infinite(norm_sr1_3$lognormconst))
     expect_false(is.infinite(norm_sr1_5$lognormconst))
     expect_false(is.infinite(norm_sr1_7$lognormconst))
 
+    expect_false(is.infinite(norm_trust_1$lognormconst))
     expect_false(is.infinite(norm_trust_3$lognormconst))
     expect_false(is.infinite(norm_trust_5$lognormconst))
     expect_false(is.infinite(norm_trust_7$lognormconst))
 
+    expect_false(is.infinite(norm_bfgs_1$lognormconst))
     expect_false(is.infinite(norm_bfgs_3$lognormconst))
     expect_false(is.infinite(norm_bfgs_5$lognormconst))
     expect_false(is.infinite(norm_bfgs_7$lognormconst))
 
+    expect_false(is.infinite(norm_sparse_2d_1$lognormconst))
     expect_false(is.infinite(norm_sparse_2d_3$lognormconst))
     expect_false(is.infinite(norm_sparse_2d_5$lognormconst))
     expect_false(is.infinite(norm_sparse_2d_7$lognormconst))
 
+    expect_false(is.infinite(norm_trust_2d_1$lognormconst))
     expect_false(is.infinite(norm_trust_2d_3$lognormconst))
     expect_false(is.infinite(norm_trust_2d_5$lognormconst))
     expect_false(is.infinite(norm_trust_2d_7$lognormconst))
 
+    expect_false(is.infinite(norm_bfgs_2d_1$lognormconst))
     expect_false(is.infinite(norm_bfgs_2d_3$lognormconst))
     expect_false(is.infinite(norm_bfgs_2d_5$lognormconst))
     expect_false(is.infinite(norm_bfgs_2d_7$lognormconst))
 
+    expect_false(is.infinite(norm_sr1_2d_1$lognormconst))
     expect_false(is.infinite(norm_sr1_2d_3$lognormconst))
     expect_false(is.infinite(norm_sr1_2d_5$lognormconst))
     expect_false(is.infinite(norm_sr1_2d_7$lognormconst))
 
+    expect_false(is.infinite(norm_sparse_3d_1$lognormconst))
     expect_false(is.infinite(norm_sparse_3d_3$lognormconst))
     expect_false(is.infinite(norm_sparse_3d_5$lognormconst))
     expect_false(is.infinite(norm_sparse_3d_7$lognormconst))
 
+    expect_false(is.infinite(norm_trust_3d_1$lognormconst))
     expect_false(is.infinite(norm_trust_3d_3$lognormconst))
     expect_false(is.infinite(norm_trust_3d_5$lognormconst))
     expect_false(is.infinite(norm_trust_3d_7$lognormconst))
 
+    expect_false(is.infinite(norm_bfgs_3d_1$lognormconst))
     expect_false(is.infinite(norm_bfgs_3d_3$lognormconst))
     expect_false(is.infinite(norm_bfgs_3d_5$lognormconst))
     expect_false(is.infinite(norm_bfgs_3d_7$lognormconst))
 
+    expect_false(is.infinite(norm_sr1_3d_1$lognormconst))
     expect_false(is.infinite(norm_sr1_3d_3$lognormconst))
     expect_false(is.infinite(norm_sr1_3d_5$lognormconst))
     expect_false(is.infinite(norm_sr1_3d_7$lognormconst))
@@ -152,50 +188,62 @@ test_that("Normalization works",{
     expect_error(normalize_logpost(opt_sparsetrust,2.5))
 
     # Normconst actually equals the correct thing
+    expect_equal(round(norm_sparse_1$lognormconst,2),round(truelognormconst,2))
     expect_equal(round(norm_sparse_3$lognormconst,2),round(truelognormconst,2))
     expect_equal(round(norm_sparse_5$lognormconst,3),round(truelognormconst,3))
     expect_equal(round(norm_sparse_7$lognormconst,3),round(truelognormconst,3))
 
+    expect_equal(round(norm_sr1_1$lognormconst,2),round(truelognormconst,2))
     expect_equal(round(norm_sr1_3$lognormconst,2),round(truelognormconst,2))
     expect_equal(round(norm_sr1_5$lognormconst,3),round(truelognormconst,3))
     expect_equal(round(norm_sr1_7$lognormconst,3),round(truelognormconst,3))
 
+    expect_equal(round(norm_trust_1$lognormconst,2),round(truelognormconst,2))
     expect_equal(round(norm_trust_3$lognormconst,2),round(truelognormconst,2))
     expect_equal(round(norm_trust_5$lognormconst,3),round(truelognormconst,3))
     expect_equal(round(norm_trust_7$lognormconst,3),round(truelognormconst,3))
 
+    expect_equal(round(norm_bfgs_1$lognormconst,2),round(truelognormconst,2))
     expect_equal(round(norm_bfgs_3$lognormconst,2),round(truelognormconst,2))
     expect_equal(round(norm_bfgs_5$lognormconst,3),round(truelognormconst,3))
     expect_equal(round(norm_bfgs_7$lognormconst,3),round(truelognormconst,3))
 
+    expect_equal(round(norm_sparse_2d_1$lognormconst,1),round(truelognormconst2d,1))
     expect_equal(round(norm_sparse_2d_3$lognormconst,1),round(truelognormconst2d,1))
     expect_equal(round(norm_sparse_2d_5$lognormconst,2),round(truelognormconst2d,2))
     expect_equal(round(norm_sparse_2d_7$lognormconst,2),round(truelognormconst2d,2))
 
+    expect_equal(round(norm_trust_2d_1$lognormconst,1),round(truelognormconst2d,1))
     expect_equal(round(norm_trust_2d_3$lognormconst,1),round(truelognormconst2d,1))
     expect_equal(round(norm_trust_2d_5$lognormconst,2),round(truelognormconst2d,2))
     expect_equal(round(norm_trust_2d_7$lognormconst,2),round(truelognormconst2d,2))
 
+    expect_equal(round(norm_bfgs_2d_1$lognormconst,1),round(truelognormconst2d,1))
     expect_equal(round(norm_bfgs_2d_3$lognormconst,1),round(truelognormconst2d,1))
     expect_equal(round(norm_bfgs_2d_5$lognormconst,2),round(truelognormconst2d,2))
     expect_equal(round(norm_bfgs_2d_7$lognormconst,2),round(truelognormconst2d,2))
 
+    expect_equal(round(norm_sr1_2d_1$lognormconst,1),round(truelognormconst2d,1))
     expect_equal(round(norm_sr1_2d_3$lognormconst,1),round(truelognormconst2d,1))
     expect_equal(round(norm_sr1_2d_5$lognormconst,2),round(truelognormconst2d,2))
     expect_equal(round(norm_sr1_2d_7$lognormconst,2),round(truelognormconst2d,2))
 
+    expect_equal(round(norm_sparse_3d_1$lognormconst,0),round(truelognormconst3d,0)) # Less accurate with 1 point in 3d
     expect_equal(round(norm_sparse_3d_3$lognormconst,0),round(truelognormconst3d,0)) # Less accurate with 3 points in 3d
     expect_equal(round(norm_sparse_3d_5$lognormconst,2),round(truelognormconst3d,2))
     expect_equal(round(norm_sparse_3d_7$lognormconst,2),round(truelognormconst3d,2))
 
+    expect_equal(round(norm_trust_3d_1$lognormconst,0),round(truelognormconst3d,0))
     expect_equal(round(norm_trust_3d_3$lognormconst,0),round(truelognormconst3d,0))
     expect_equal(round(norm_trust_3d_5$lognormconst,2),round(truelognormconst3d,2))
     expect_equal(round(norm_trust_3d_7$lognormconst,2),round(truelognormconst3d,2))
 
+    expect_equal(round(norm_bfgs_3d_1$lognormconst,0),round(truelognormconst3d,0))
     expect_equal(round(norm_bfgs_3d_3$lognormconst,0),round(truelognormconst3d,0))
     expect_equal(round(norm_bfgs_3d_5$lognormconst,2),round(truelognormconst3d,2))
     expect_equal(round(norm_bfgs_3d_7$lognormconst,2),round(truelognormconst3d,2))
 
+    expect_equal(round(norm_sr1_3d_1$lognormconst,0),round(truelognormconst3d,0))
     expect_equal(round(norm_sr1_3d_3$lognormconst,0),round(truelognormconst3d,0))
     expect_equal(round(norm_sr1_3d_5$lognormconst,2),round(truelognormconst3d,2))
     expect_equal(round(norm_sr1_3d_7$lognormconst,2),round(truelognormconst3d,2))


### PR DESCRIPTION
Attempted fix for #6:

1. Removed separate for loop for `k =  1` so that output is of the same format as `k > 1` so that AGHQ can be run with `k = 1` in later functions without throwing errors
2. Added unit tests for `k = 1`

I tried `devtools::test()` but got an error on "Beginning optimization" which I'd guess is before the edits I made.

Some other small changes to the unit tests which could be good:

1. `setup-01-optimization.R` presumably does set-up for al of the unit tests, so why is it `01-optimization`?
2. Doing some quick searching `context` is [recommended against](https://testthat.r-lib.org/reference/context.html). If it's not there file names will be used instead 